### PR TITLE
Allow T4 gradient to cover outer tiers

### DIFF
--- a/config.js
+++ b/config.js
@@ -178,7 +178,7 @@ const tiers = [
   {
     key: "T4",
     innerRadius: 120,
-    outerRadius: 220,
+    outerRadius: 500,
     rotationLocked: false,
     divisionWeights: t4Weights,
     labelList: [
@@ -276,7 +276,11 @@ const tiers = [
       anchor: "middle",
       verticalAlign: "middle"
     },
-   // fill: { mode: "inherit" },
+    fill: {
+      mode: "solid",
+      startColor: "#00000000",
+      endColor: "#00000000"
+    },
     overlay: {
       mode: "shade",
       color: "#000000",
@@ -305,7 +309,11 @@ const tiers = [
       anchor: "start",
       verticalAlign: "middle"
     },
-    // fill: { mode: "inherit" },
+    fill: {
+      mode: "solid",
+      startColor: "#00000000",
+      endColor: "#00000000"
+    },
     overlay: {
       mode: "tint",
       color: "#ffffff",
@@ -371,6 +379,13 @@ const overlays = [
     radius: tiers[6].outerRadius,
     width: renderOptions.strokeDefaults.normal,
     color: "#000"
+  },
+  {
+    visible: true,
+    type: 'ringOutline',
+    radius: 220,
+    width: renderOptions.strokeDefaults.wide,
+    color: '#000'
   },
   {
     visible: true,

--- a/main.js
+++ b/main.js
@@ -205,7 +205,9 @@ function drawRadialTier(svg, config, tierIndex, cx, cy, rotationOffset, defs) {
     path.setAttribute('d', d);
 
     let segmentFill = '#ccc';
-    if (config.fill?.mode === 'manual') {
+    if (config.fill?.mode === 'solid') {
+      segmentFill = config.fill.startColor || '#fff';
+    } else if (config.fill?.mode === 'manual') {
       segmentFill = config.fill.colorList?.[i] || segmentFill;
     } else if (config.fill?.mode === 'gradient-manual') {
       const pair = config.fill.gradientPairs?.[i];


### PR DESCRIPTION
## Summary
- let radial tiers support `solid` fills so we can render transparent segments
- extend Tier 4's outerRadius so its gradient spans the wheel
- add transparent fills to T5/T6 and keep overlays
- draw a new ring outline at the original T4 boundary

## Testing
- `npm test` *(fails: could not reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6863bfe0ae74832281fe25a3d1700bfb