### PR TITLE
Implement zoom viewport feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ and track the current rotation angle.
 
 T0–T2 have rotationLocked: true
 
+🔍 Zoom Viewport
+
+The wheel is wrapped in a `.wheel-viewport` container that hides any
+overflow. `main.js` includes `zoomSlice`, `zoomScale`, and `zoomOffset`
+variables and an `updateViewport()` helper that applies a CSS transform so
+the chosen slice stays centered. Use the **Toggle Zoom** button in
+`index.html` to enable or disable zoom on the first slice.
+
 🖼️ Overlays
 
 T4–T6 can include visual overlays via overlay block

--- a/index.html
+++ b/index.html
@@ -27,10 +27,16 @@
     <button data-t6="thriveCounter">Thrive</button>
   </div>
 
+  <div id="zoom-controls">
+    <button id="zoom-toggle">Toggle Zoom</button>
+  </div>
+
   <br />
 
   <!-- Wheel SVG Container -->
-  <svg id="dim-wheel" width="1000" height="1000"></svg>
+  <div class="wheel-viewport">
+    <svg id="dim-wheel" width="1000" height="1000"></svg>
+  </div>
 
   <script type="module" src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -9,6 +9,32 @@ let currentRotation = 0;
 // Sequential ID generator for arc paths used by arc text
 let arcPathCounter = 0;
 
+// === VIEWPORT / ZOOM ===
+let zoomSlice = null;
+const zoomScale = 2;
+const zoomOffset = 300;
+const viewport = document.querySelector('.wheel-viewport');
+
+function updateViewport() {
+  if (!viewport) return;
+  const vw = viewport.clientWidth;
+  const vh = viewport.clientHeight;
+  let scale = 1;
+  let offsetX = vw / 2 - wheelConfig.centerX;
+  let offsetY = vh / 2 - wheelConfig.centerY;
+
+  if (zoomSlice !== null) {
+    scale = zoomScale;
+    const angle = ((zoomSlice + 0.5 + currentRotation) / wheelConfig.globalDivisionCount) * 2 * Math.PI - Math.PI / 2;
+    const x = wheelConfig.centerX + zoomOffset * Math.cos(angle);
+    const y = wheelConfig.centerY + zoomOffset * Math.sin(angle);
+    offsetX = vw / 2 - x * scale;
+    offsetY = vh / 2 - y * scale;
+  }
+
+  svg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
+}
+
 // === RENDER ENTRY POINT ===
 function renderWheel() {
   arcPathCounter = 0;
@@ -41,6 +67,8 @@ function renderWheel() {
   if (wheelConfig.renderOptions?.debugRenderOutlines) {
     drawBoundaries(svg, wheelConfig.tiers, centerX, centerY);
   }
+
+  updateViewport();
 }
 
 // === BUTTON SETUP FUNCTIONS ===
@@ -51,6 +79,7 @@ function setupRotationButtons() {
       btn.addEventListener('click', () => {
         currentRotation = (currentRotation + value + wheelConfig.globalDivisionCount) % wheelConfig.globalDivisionCount;
         renderWheel();
+        updateViewport();
       });
     }
   });
@@ -64,8 +93,19 @@ function setupT6Buttons() {
       button.addEventListener('click', () => {
         wheelConfig.tiers[6].labelListSource = source;
         renderWheel();
+        updateViewport();
       });
     }
+  });
+}
+
+// === ZOOM CONTROL ===
+function setupZoomButton() {
+  const btn = document.getElementById('zoom-toggle');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    zoomSlice = zoomSlice === null ? 0 : null;
+    updateViewport();
   });
 }
 
@@ -484,4 +524,5 @@ function polarToCartesian(cx, cy, r, angleDeg) {
 // === INIT ===
 setupRotationButtons();
 setupT6Buttons();
+setupZoomButton();
 renderWheel();

--- a/style.css
+++ b/style.css
@@ -37,6 +37,14 @@ h2 {
   border-radius: 50%;
 }
 
+.wheel-viewport {
+  width: 400px;
+  height: 400px;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 16px;
+}
+
 /* === BUTTON STYLE === */
 button {
   padding: 6px 12px;


### PR DESCRIPTION
## Summary
- wrap wheel SVG in a new `.wheel-viewport` element
- style the viewport to hide overflow
- add zoom variables and `updateViewport()` in `main.js`
- toggle zoom with a new button and document the feature

## Testing
- `npm test` *(fails: ENOA internet)*

------
https://chatgpt.com/codex/tasks/task_e_68644da38dbc83229a91fe989acf539a