### PR TITLE
Anchor wheel center to viewport edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ overflow. `main.js` includes `zoomSlice`, `zoomScale`, and `zoomOffset`
 variables and an `updateViewport()` helper that applies a CSS transform so
 the chosen slice stays centered. Use the **Toggle Zoom** button in
 `index.html` to enable or disable zoom on the first slice.
+`updateViewport()` also respects a `viewportAnchorX` constant for positioning
+the wheel's center relative to the left edge of the viewport.
 
 🖼️ Overlays
 

--- a/main.js
+++ b/main.js
@@ -14,22 +14,26 @@ let zoomSlice = null;
 const zoomScale = 2;
 const zoomOffset = 300;
 const viewport = document.querySelector('.wheel-viewport');
+// Anchor point for wheel positioning (relative to the top-left of viewport)
+const viewportAnchorX = 0; // horizontal offset from left edge
 
 function updateViewport() {
   if (!viewport) return;
   const vw = viewport.clientWidth;
   const vh = viewport.clientHeight;
   let scale = 1;
-  let offsetX = vw / 2 - wheelConfig.centerX;
-  let offsetY = vh / 2 - wheelConfig.centerY;
+  const anchorX = viewportAnchorX;
+  const anchorY = vh / 2;
+  let offsetX = anchorX - wheelConfig.centerX;
+  let offsetY = anchorY - wheelConfig.centerY;
 
   if (zoomSlice !== null) {
     scale = zoomScale;
     const angle = ((zoomSlice + 0.5 + currentRotation) / wheelConfig.globalDivisionCount) * 2 * Math.PI - Math.PI / 2;
     const x = wheelConfig.centerX + zoomOffset * Math.cos(angle);
     const y = wheelConfig.centerY + zoomOffset * Math.sin(angle);
-    offsetX = vw / 2 - x * scale;
-    offsetY = vh / 2 - y * scale;
+    offsetX = anchorX - x * scale;
+    offsetY = anchorY - y * scale;
   }
 
   svg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;


### PR DESCRIPTION
## Summary
- add `viewportAnchorX` in `main.js` and update viewport translations so the wheel can be aligned to the left edge
- mention `viewportAnchorX` in README

## Testing
- `npm test` *(fails: Unknown env config due to offline)*

------
https://chatgpt.com/codex/tasks/task_e_686456bffd9083228dfc944438a5659a