### PR TITLE
Align wheel center in zoom-out view

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,14 +15,16 @@ const zoomScale = 2;
 const zoomOffset = 300;
 const viewport = document.querySelector('.wheel-viewport');
 // Anchor point for wheel positioning (relative to the top-left of viewport)
-const viewportAnchorX = 0; // horizontal offset from left edge
+// Horizontal offset from the left edge. Set to `null` to center based on
+// the viewport width.
+const viewportAnchorX = null;
 
 function updateViewport() {
   if (!viewport) return;
   const vw = viewport.clientWidth;
   const vh = viewport.clientHeight;
   let scale = 1;
-  const anchorX = viewportAnchorX;
+  const anchorX = viewportAnchorX !== null ? viewportAnchorX : vw / 2;
   const anchorY = vh / 2;
   let offsetX = anchorX - wheelConfig.centerX;
   let offsetY = anchorY - wheelConfig.centerY;

--- a/style.css
+++ b/style.css
@@ -38,8 +38,8 @@ h2 {
 }
 
 .wheel-viewport {
-  width: 400px;
-  height: 400px;
+  width: 500px;
+  height: 500px;
   position: relative;
   overflow: hidden;
   margin-bottom: 16px;


### PR DESCRIPTION
## Summary
- enlarge wheel viewport to 500x500
- center wheel horizontally when zoom is disabled

## Testing
- `npm test` *(fails: Unknown env config warning)*

------
https://chatgpt.com/codex/tasks/task_e_68645ca8b1b88322a49bf98433624d01