### PR TITLE
Remove redundant viewport updates

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,7 +88,6 @@ function setupRotationButtons() {
       btn.addEventListener('click', () => {
         currentRotation = (currentRotation + value + wheelConfig.globalDivisionCount) % wheelConfig.globalDivisionCount;
         renderWheel();
-        updateViewport();
       });
     }
   });
@@ -102,7 +101,6 @@ function setupT6Buttons() {
       button.addEventListener('click', () => {
         wheelConfig.tiers[6].labelListSource = source;
         renderWheel();
-        updateViewport();
       });
     }
   });


### PR DESCRIPTION
## Summary
- clean up setupRotationButtons() and setupT6Buttons() by removing extra `updateViewport()` calls
- keep zoom control functionality unaffected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68651b34e9508322af1e2c590a0f4321