### PR TITLE
Fix zoomed viewport anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ variables and an `updateViewport()` helper that applies a CSS transform so
 the chosen slice stays centered. Use the **Toggle Zoom** button in
 `index.html` to enable or disable zoom on the first slice. When zoomed
 in, the viewport gains a `zoomed` class (1200×500) and the wheel is
-anchored to the left edge. When zoomed out, the viewport reverts to a
-500×500 square and the wheel is centered automatically.
-`zoomedAnchorX` and `defaultAnchorX` control these anchor positions.
-`zoomedAnchorX` locks the wheel to the left edge in the wide view,
-while `defaultAnchorX` defines the centered position for the
+anchored by its center along the left edge. When zoomed out, the
+viewport reverts to a 500×500 square and the wheel is centered
+automatically. `zoomedAnchorX` and `defaultAnchorX` control these
+anchor positions. `zoomedAnchorX` locks the wheel's center to the left
+edge in the wide view, while `defaultAnchorX` defines the centered
+position for the
 500×500 state. Both constants live in `main.js` right above the
 `updateViewport()` helper for quick customization.
 

--- a/main.js
+++ b/main.js
@@ -16,7 +16,8 @@ const zoomOffset = 300;
 const viewport = document.querySelector('.wheel-viewport');
 
 // Viewport anchor positions for each zoom state
-const zoomedAnchorX = 0;       // left aligned when zoomed in
+// Use the wheel's centerX so the left edge stays flush when zoomed.
+const zoomedAnchorX = wheelConfig.centerX;       // left aligned when zoomed in
 const defaultAnchorX = null;   // centered when zoomed out
 
 function updateViewport() {


### PR DESCRIPTION
## Summary
- anchor zoomed view to wheel's center so the left edge stays flush
- clarify documentation for zoomed viewport anchors

## Testing
- `npm test` *(fails: could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68651a05f3ac8322b3216b791ef4bb08