### PR TITLE
Ensure centered zoom/rotation

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,7 +42,8 @@ function updateViewport() {
     offsetY = anchorY - y * scale;
   }
 
-  svg.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`;
+  // Apply scaling before translation so zoom occurs about the center
+  svg.style.transform = `scale(${scale}) translate(${offsetX}px, ${offsetY}px)`;
 }
 
 // === RENDER ENTRY POINT ===

--- a/style.css
+++ b/style.css
@@ -35,6 +35,7 @@ h2 {
   background: white;
   border: 2px solid #aaa;
   border-radius: 50%;
+  transform-origin: 50% 50%;
 }
 
 .wheel-viewport {


### PR DESCRIPTION
## Summary
- keep wheel rotation & zoom centered with `transform-origin`
- apply `scale()` before `translate()` in viewport update

## Testing
- `npm test` *(fails: unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_68652b3f443083228256ef8237f15258