### PR TITLE
Simplify viewport zoom logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,19 +138,23 @@ T0–T2 have rotationLocked: true
 🔍 Zoom Viewport
 
 The wheel is wrapped in a `.wheel-viewport` container that hides any
-overflow. `main.js` includes `zoomSlice`, `zoomScale`, and `zoomOffset`
-variables and an `updateViewport()` helper that applies a CSS transform so
-the chosen slice stays centered. Use the **Toggle Zoom** button in
-`index.html` to enable or disable zoom on the first slice. When zoomed
-in, the viewport gains a `zoomed` class (1200×500) and the wheel is
-anchored by its center along the left edge. When zoomed out, the
-viewport reverts to a 500×500 square and the wheel is centered
-automatically. `zoomedAnchorX` and `defaultAnchorX` control these
-anchor positions. `zoomedAnchorX` locks the wheel's center to the left
-edge in the wide view, while `defaultAnchorX` defines the centered
-position for the
-500×500 state. Both constants live in `main.js` right above the
-`updateViewport()` helper for quick customization.
+overflow. `main.js` now exposes a pair of static transform presets used by
+`updateViewport()`:
+
+```
+NORMAL_SCALE   = 1
+NORMAL_OFFSET_X = -250
+NORMAL_OFFSET_Y = -250
+ZOOM_SCALE     = 2
+ZOOM_OFFSET_X  = -514
+ZOOM_OFFSET_Y  = -150
+```
+
+The **Toggle Zoom** button simply switches between these presets. When
+zoomed in, the viewport gains a `zoomed` class (1200×500) and the wheel is
+anchored near the left edge. Zooming out restores the 500×500 viewport and
+centers the wheel. `TRANSFORM_ORIGIN` (50% 50%) is shared between the CSS
+and JavaScript so the scale happens about the wheel's center.
 
 🖼️ Overlays
 

--- a/main.js
+++ b/main.js
@@ -10,37 +10,25 @@ let currentRotation = 0;
 let arcPathCounter = 0;
 
 // === VIEWPORT / ZOOM ===
-let zoomSlice = null;
-const zoomScale = 2;
-const zoomOffset = 300;
+let isZoomed = false;
 const viewport = document.querySelector('.wheel-viewport');
 
-// Viewport anchor positions for each zoom state
-// Use the wheel's centerX so the left edge stays flush when zoomed.
-const zoomedAnchorX = wheelConfig.centerX;       // left aligned when zoomed in
-const defaultAnchorX = null;   // centered when zoomed out
+// Fixed transform presets for each state
+const TRANSFORM_ORIGIN = '50% 50%';
+const NORMAL_SCALE = 1;
+const NORMAL_OFFSET_X = -250;
+const NORMAL_OFFSET_Y = -250;
+const ZOOM_SCALE = 2;
+const ZOOM_OFFSET_X = -514;
+const ZOOM_OFFSET_Y = -150;
 
 function updateViewport() {
   if (!viewport) return;
-  viewport.classList.toggle('zoomed', zoomSlice !== null);
-  const vw = viewport.clientWidth;
-  const vh = viewport.clientHeight;
-  let scale = 1;
-  const anchorX = zoomSlice !== null
-    ? zoomedAnchorX
-    : (defaultAnchorX !== null ? defaultAnchorX : vw / 2);
-  const anchorY = vh / 2;
-  let offsetX = anchorX - wheelConfig.centerX;
-  let offsetY = anchorY - wheelConfig.centerY;
+  viewport.classList.toggle('zoomed', isZoomed);
 
-  if (zoomSlice !== null) {
-    scale = zoomScale;
-    const angle = ((zoomSlice + 0.5 + currentRotation) / wheelConfig.globalDivisionCount) * 2 * Math.PI - Math.PI / 2;
-    const x = wheelConfig.centerX + zoomOffset * Math.cos(angle);
-    const y = wheelConfig.centerY + zoomOffset * Math.sin(angle);
-    offsetX = anchorX - x * scale;
-    offsetY = anchorY - y * scale;
-  }
+  const scale = isZoomed ? ZOOM_SCALE : NORMAL_SCALE;
+  const offsetX = isZoomed ? ZOOM_OFFSET_X : NORMAL_OFFSET_X;
+  const offsetY = isZoomed ? ZOOM_OFFSET_Y : NORMAL_OFFSET_Y;
 
   // Apply scaling before translation so zoom occurs about the center
   svg.style.transform = `scale(${scale}) translate(${offsetX}px, ${offsetY}px)`;
@@ -113,7 +101,7 @@ function setupZoomButton() {
   const btn = document.getElementById('zoom-toggle');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    zoomSlice = zoomSlice === null ? 0 : null;
+    isZoomed = !isZoomed;
     updateViewport();
   });
 }

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ h2 {
   background: white;
   border: 2px solid #aaa;
   border-radius: 50%;
-  transform-origin: 50% 50%;
+  transform-origin: 50% 50%; /* matches TRANSFORM_ORIGIN in main.js */
 }
 
 .wheel-viewport {


### PR DESCRIPTION
## Summary
- add fixed presets for zoom and normal viewport transforms
- rewrite `updateViewport()` to use the new constants
- toggle a new `isZoomed` flag via the zoom button
- keep `#dim-wheel` anchored with a consistent transform origin
- document the numeric presets in the README

## Testing
- `npm test` *(fails: Unknown env config "http-proxy")*

------
https://chatgpt.com/codex/tasks/task_e_68657758eca08322bc275a79a0fe3dac