### PR TITLE
Add overlay content validation check

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,9 @@ Then open [http://localhost:8000/index.html](http://localhost:8000/index.html) i
 There are currently no automated tests for this project.
 The `npm test` script is intentionally empty and exists only to
 prevent errors when running `npm test`.
+
+### Data validation
+
+Run `npm run validate` to ensure `overlayContent.js` still contains exactly 132
+entries and each entry has 25 fields. This quick check guards against accidental
+data corruption.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "license": "CC-BY-NC-4.0",
   "scripts": {
-    "test": ""
+    "test": "",
+    "validate": "node validate.js"
   }
 }

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,24 @@
+import overlayContent from './overlayContent.js';
+
+const expectedLength = 132;
+const expectedFields = 25;
+
+if (!Array.isArray(overlayContent)) {
+  console.error('overlayContent is not an array');
+  process.exit(1);
+}
+
+if (overlayContent.length !== expectedLength) {
+  console.error(`overlayContent should have ${expectedLength} entries but has ${overlayContent.length}`);
+  process.exit(1);
+}
+
+for (let i = 0; i < overlayContent.length; i++) {
+  const entry = overlayContent[i];
+  if (!Array.isArray(entry) || entry.length !== expectedFields) {
+    console.error(`Entry at index ${i} should have ${expectedFields} fields but has ${Array.isArray(entry) ? entry.length : 'not an array'}`);
+    process.exit(1);
+  }
+}
+
+console.log('overlayContent validation passed');


### PR DESCRIPTION
## Summary
- add a simple `validate.js` script to check overlayContent.js
- expose `npm run validate` task
- document validation script in README

## Testing
- `npm run validate` *(fails: Entry at index 24 should have 25 fields but has 26)*

------
https://chatgpt.com/codex/tasks/task_e_687d21b1a61483228e9967dbc2bd2296