### PR TITLE
Fix overlay field indices in wheelData

### DIFF
--- a/wheelData.js
+++ b/wheelData.js
@@ -2,11 +2,11 @@
 
 import overlayContent from './overlayContent.js';
 
-const quotes = overlayContent.map(o => o[21]);
-const emotion = overlayContent.map(o => o[22]);
-const tone = overlayContent.map(o => o[20]);
-const behavior = overlayContent.map(o => o[19]);
-const thriveCounter = overlayContent.map(o => o[24]);
+const quotes = overlayContent.map(o => o[19]);
+const emotion = overlayContent.map(o => o[20]);
+const tone = overlayContent.map(o => o[18]);
+const behavior = overlayContent.map(o => o[17]);
+const thriveCounter = overlayContent.map(o => o[23]);
 
 export const wheelData = {
   // T0–T2: Single labels


### PR DESCRIPTION
## Summary
- pull the correct overlayContent fields for the `wheelData` arrays

## Testing
- `npm run validate` *(fails: Entry at index 24 should have 25 fields but has 26)*

------
https://chatgpt.com/codex/tasks/task_e_687d243472d88322987cd7d4731140f5