### PR TITLE
Update T6 data source config

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ labelList: Local list of strings or generated (e.g. T5 modifiers)
 
 labelListSource: Used in T6 to switch which overlay field is shown
 
-availableSources: ["quotes", "emotion", "tone", "behavior", "thriveCounter"]
+availableSources: ["overlayContent"]
 
 T6 labels now come entirely from `overlayContent.js`, which contains 132
 rows of 25 fields. Key indexes are:
@@ -125,13 +125,13 @@ stand‑alone dataset files have been removed.
 
 🧪 T6 Data Switching
 
-T6 label set is dynamic
+T6 label set is dynamic.
+Button-style UI options change `tiers[6].labelListSource` to select
+different fields from `wheelData` (quotes, emotion, tone, behavior, etc.).
+The `availableSources` array no longer lists these options—datasets are
+defined entirely in `wheelData.js`.
 
-Button-style UI options allow live toggling between datasets
-
-Entire dataset is pulled via labelListSource key
-
-Each T6 state maps 1:1 with existing 132 segment structure
+Each T6 state maps 1:1 with the existing 132 segment structure.
 
 🔄 Rotation Modes
 

--- a/config.js
+++ b/config.js
@@ -305,8 +305,8 @@ const tiers = [  // Master configuration for all wheel rings
     outerRadius: 500,
     rotationLocked: false,
     divisionWeights: t4DivisionAngles.map(() => 1),
-    labelListSource: "quotes",
-    availableSources: ["quotes", "emotion", "tone", "behavior", "thriveCounter"],
+    labelListSource: "overlayContent",
+    availableSources: ["overlayContent"],
     labelStyle: {
       type: "radial",
       fontSize: 6,
@@ -423,5 +423,5 @@ export const wheelConfig = {
   renderOptions,
   tiers,
   overlays,
-  availableSources: ["quotes", "emotion", "tone", "behavior", "thriveCounter"]
+  availableSources: ["overlayContent"]
 };

--- a/wheelData.js
+++ b/wheelData.js
@@ -52,6 +52,7 @@ export const wheelData = {
   })(),
 
   // T6 variants
+  overlayContent,
   quotes,
   emotion,
   tone,


### PR DESCRIPTION
## Summary
- set Tier 6 `labelListSource` to `overlayContent`
- limit config `availableSources` to `["overlayContent"]`
- expose `overlayContent` directly in `wheelData`
- document dataset switching through `wheelData`

## Testing
- `npm test`
- `npm run validate` *(fails: Entry at index 24 should have 25 fields but has 26)*

------
https://chatgpt.com/codex/tasks/task_e_687d24ec479083229a075ca03d56bb43