### PR TITLE
Default to behavior dataset for T6

### DIFF
--- a/config.js
+++ b/config.js
@@ -305,7 +305,7 @@ const tiers = [  // Master configuration for all wheel rings
     outerRadius: 500,
     rotationLocked: false,
     divisionWeights: t4DivisionAngles.map(() => 1),
-    labelListSource: "overlayContent",
+    labelListSource: "behavior",
     availableSources: ["overlayContent"],
     labelStyle: {
       type: "radial",

--- a/main.js
+++ b/main.js
@@ -85,15 +85,23 @@ function setupRotationButtons() {
 
 // === T6 DATASET SWITCHING ===
 function setupT6Buttons() {
-  document.querySelectorAll('[data-t6]').forEach(button => {
+  const buttons = document.querySelectorAll('[data-t6]');
+  buttons.forEach(button => {
     const source = button.getAttribute('data-t6');
     if (source) {
       button.addEventListener('click', () => {
         wheelConfig.tiers[6].labelListSource = source;
         renderWheel();
+        buttons.forEach(btn => btn.classList.remove('active'));
+        button.classList.add('active');
       });
     }
   });
+
+  const defaultBtn = document.querySelector('[data-t6="behavior"]');
+  if (defaultBtn) {
+    defaultBtn.classList.add('active');
+  }
 }
 
 // === ZOOM CONTROL ===

--- a/style.css
+++ b/style.css
@@ -64,3 +64,8 @@ button {
 button:hover {
   background-color: #eee;
 }
+
+button.active {
+  background-color: #ddd;
+  border-color: #555;
+}


### PR DESCRIPTION
## Summary
- switch the default Tier 6 dataset to **behavior**
- highlight the selected Tier 6 dataset button
- add CSS style for active buttons

## Testing
- `npm run validate` *(fails: Entry at index 57 should have 25 fields but has 26)*

------
https://chatgpt.com/codex/tasks/task_e_688230af72c0832282613eed89d69334