### PR TITLE
Initialize wheel with rotation offset

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,8 @@ import { wheelData } from './wheelData.js';
 
 const svg = document.getElementById('dim-wheel');
 // Rotation index for global divisions; modified via the UI
-let currentRotation = 0;
+// Start a quarter-turn offset so that T4 centers align correctly on load
+let currentRotation = wheelConfig.globalDivisionCount / 4;
 // Currently selected overlay index for info panel
 let selectedIndex = 0;
 // Sequential ID generator for arc paths used by arc text


### PR DESCRIPTION
## Summary
- start the wheel rotated 1/4 turn so default segments align
- keep info panel index at zero and continue updating alongside rotation

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_688233c4b2b4832290e445601f164d93