### PR TITLE
Add full overlay info panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,44 @@ anchored near the left edge. Zooming out restores the 500×500 viewport and
 centers the wheel. `TRANSFORM_ORIGIN` (50% 50%) is shared between the CSS
 and JavaScript so the scale happens about the wheel's center.
 
+ℹ️ Info Panel
+--------------
+
+When zoomed in, a side panel displays detailed data for the currently
+selected segment. `updateInfoPanel()` reads from `overlayContent.js` and
+groups fields into five sections:
+
+1. **Grounding: Naming the Pattern**
+   - `1` – Description
+   - `2` – Academic Framing
+   - `3` – Philosophical Angle
+   - `5` – Alternate Phrasings
+2. **Trigger & Activation: What Sparks It**
+   - `4` – Internal Trigger Phrase
+   - `6` – Behaviour Function
+   - `7` – Goal / Purpose
+   - `8` – Push Vector
+   - `9` – Motion Feel
+3. **Embodied Impact: How It Moves Through**
+   - `10` – Somatic Pattern
+   - `11` – Feltframe
+   - `12` – Narrative Rhythm
+   - `13` – Archetypes
+   - `14` – Simulation Tag
+   - `16` – Intensity Range
+4. **Expression**
+   - `17` – Behaviour
+   - `18` – Tone
+   - `19` – Expression Quote
+   - `20` – Emotion
+5. **Alignment & Edge: How it lands, how it breaks, and how it grows**
+   - `21` – Typical Reaction
+   - `22` – Behavioural Opposite
+   - `23` – Thrive Counter-Quote
+   - `24` – Wisdom
+
+The panel appears below the wheel when zoomed in and hides when zoomed out.
+
 🖼️ Overlays
 
 T4–T6 can include visual overlays via overlay block

--- a/main.js
+++ b/main.js
@@ -47,13 +47,69 @@ function updateInfoPanel(index) {
   const data = wheelData.overlayContent?.[index];
   if (!panel || !data) return;
 
-  const idTag = `<span style="float:right;color:gray;font-size:0.8rem">${data[0]}</span>`;
+  const sections = [
+    {
+      title: 'Grounding: Naming the Pattern',
+      items: [
+        ['Description', data[1]],
+        ['Academic Framing', data[2]],
+        ['Philosophical Angle', data[3]],
+        ['Alternate Phrasings', data[5]]
+      ]
+    },
+    {
+      title: 'Trigger & Activation: What Sparks It',
+      items: [
+        ['Internal Trigger Phrase', data[4]],
+        ['Behaviour Function', data[6]],
+        ['Goal / Purpose', data[7]],
+        ['Push Vector', data[8]],
+        ['Motion Feel', data[9]]
+      ]
+    },
+    {
+      title: 'Embodied Impact: How It Moves Through',
+      items: [
+        ['Somatic Pattern', data[10]],
+        ['Feltframe', data[11]],
+        ['Narrative Rhythm', data[12]],
+        ['Archetypes', data[13]],
+        ['Simulation Tag', data[14]],
+        ['Intensity Range', data[16]]
+      ]
+    },
+    {
+      title: 'Expression',
+      items: [
+        ['Behaviour', data[17]],
+        ['Tone', data[18]],
+        ['Expression Quote', data[19]],
+        ['Emotion', data[20]]
+      ]
+    },
+    {
+      title: 'Alignment & Edge: How it lands, how it breaks, and how it grows',
+      items: [
+        ['Typical Reaction', data[21]],
+        ['Behavioural Opposite', data[22]],
+        ['Thrive Counter-Quote', data[23]],
+        ['Wisdom', data[24]]
+      ]
+    }
+  ];
+
+  const idTag = `<div class="id-tag">ID: ${data[0]}</div>`;
   panel.innerHTML =
-    `<div>${idTag}<strong>Behavior:</strong> ${data[17]}</div>` +
-    `<div><strong>Tone:</strong> ${data[18]}</div>` +
-    `<div><strong>Quote:</strong> ${data[19]}</div>` +
-    `<div><strong>Emotion:</strong> ${data[20]}</div>` +
-    `<div><strong>Thrive:</strong> ${data[23]}</div>`;
+    idTag +
+    sections
+      .map(sec =>
+        `<div class="info-section"><h4>${sec.title}</h4>` +
+        sec.items
+          .map(([label, val]) => `<div><strong>${label}:</strong> ${val}</div>`) 
+          .join('') +
+        '</div>'
+      )
+      .join('');
 }
 
 // === RENDER ENTRY POINT ===

--- a/style.css
+++ b/style.css
@@ -57,13 +57,34 @@ h2 {
   width: 900px;
   height: 250px;
   overflow: auto;
-  font-style: italic;
-  font-size: 0.85rem;
-  line-height: 1.3;
+  font-style: normal;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  border: 1px solid #ccc;
+  padding: 8px;
+  background: #fff;
 }
 
 .wheel-viewport.zoomed + #info-panel {
   display: block;
+}
+
+#info-panel .id-tag {
+  float: right;
+  color: gray;
+  font-size: 0.8rem;
+}
+
+#info-panel h4 {
+  margin: 6px 0 2px;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.info-section {
+  margin-bottom: 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eee;
 }
 
 /* === BUTTON STYLE === */


### PR DESCRIPTION
## Summary
- show all overlayContent fields in info panel grouped into sections
- style the info panel for clarity
- document panel groups and indexes in README

## Testing
- `npm run validate`


------
https://chatgpt.com/codex/tasks/task_e_688248fe53708322bced6a099018aa51